### PR TITLE
fix: Remove Storybook parameters from CodeSandbox examples

### DIFF
--- a/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/doesnt-remove-inner-assignments-from-exported/code.js
+++ b/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/doesnt-remove-inner-assignments-from-exported/code.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export const TestComponent = () => {
+  const foo = { bar: 'baz' };
+  foo.baz = 'bar';
+  return 'Hello world';
+};
+
+TestComponent.parameters = {
+  foo: 'bar',
+};

--- a/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/doesnt-remove-inner-assignments-from-exported/output.js
+++ b/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/doesnt-remove-inner-assignments-from-exported/output.js
@@ -1,0 +1,8 @@
+import * as React from 'react';
+export const TestComponent = () => {
+  const foo = {
+    bar: 'baz',
+  };
+  foo.baz = 'bar';
+  return 'Hello world';
+};

--- a/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/doesnt-remove-params-from-not-exported/code.js
+++ b/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/doesnt-remove-params-from-not-exported/code.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+const TestComponent = () => 'Hello world';
+
+TestComponent.parameters = {
+  foo: 'bar',
+};

--- a/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/doesnt-remove-params-from-not-exported/output.js
+++ b/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/doesnt-remove-params-from-not-exported/output.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+const TestComponent = () => 'Hello world';
+
+TestComponent.parameters = {
+  foo: 'bar',
+};

--- a/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/removes-assigns-from-exported/code.js
+++ b/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/removes-assigns-from-exported/code.js
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+export const TestComponent = () => 'Hello world';
+
+TestComponent.parameters = {
+  foo: 'bar',
+};
+
+TestComponent.somethingElse = {
+  foo: 'bar',
+  test: {
+    someKey: 'foo',
+  },
+};
+
+TestComponent['parameters'] = 1;
+
+TestComponent['parameters'] = { foo: 'bar' };

--- a/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/removes-assigns-from-exported/output.js
+++ b/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/babel-plugin-remove-storybook-parameters/removes-assigns-from-exported/output.js
@@ -1,0 +1,2 @@
+import * as React from 'react';
+export const TestComponent = () => 'Hello world';

--- a/storybook-addon-export-to-codesandbox/src/plugins/fullsource.test.ts
+++ b/storybook-addon-export-to-codesandbox/src/plugins/fullsource.test.ts
@@ -1,18 +1,4 @@
-import pluginTester from 'babel-plugin-tester';
-import * as path from 'path';
 import plugin, { PLUGIN_NAME } from './fullsource';
+import pluginTester from './pluginTester';
 
-const fixturesDir = path.join(__dirname, `__fixtures__/${PLUGIN_NAME}`);
-
-const defaultDependencyReplace = { replace: '@fluentui/react-components' };
-
-pluginTester({
-  pluginOptions: {
-    '@fluentui/react-button': defaultDependencyReplace,
-    '@fluentui/react-menu': defaultDependencyReplace,
-    '@fluentui/react-link': defaultDependencyReplace,
-  },
-  pluginName: PLUGIN_NAME,
-  plugin,
-  fixtures: fixturesDir,
-});
+pluginTester(plugin, PLUGIN_NAME);

--- a/storybook-addon-export-to-codesandbox/src/plugins/fullsource.ts
+++ b/storybook-addon-export-to-codesandbox/src/plugins/fullsource.ts
@@ -1,5 +1,6 @@
 import * as Babel from '@babel/core';
 import modifyImportsPlugin from './modifyImports';
+import removeStorybookParameters from './removeStorybookParameters';
 
 export const PLUGIN_NAME = 'storybook-stories-fullsource';
 
@@ -44,7 +45,7 @@ export default function (babel: typeof Babel, options: BabelPluginOptions): Babe
           const transformedCode = babel.transformSync(path.node.init.value, {
             ...state.file.opts,
             comments: false,
-            plugins: [[modifyImportsPlugin, options]],
+            plugins: [[modifyImportsPlugin, options], removeStorybookParameters],
           }).code;
 
           path.get('init').replaceWith(t.stringLiteral(transformedCode));

--- a/storybook-addon-export-to-codesandbox/src/plugins/modifyImports.test.ts
+++ b/storybook-addon-export-to-codesandbox/src/plugins/modifyImports.test.ts
@@ -1,17 +1,6 @@
-import pluginTester from 'babel-plugin-tester';
-import * as path from 'path';
 import plugin, { PLUGIN_NAME } from './modifyImports';
+import pluginTester from './pluginTester';
 
-const defaultDependencyReplace = { replace: '@fluentui/react-components' };
-const fixturesDir = path.join(__dirname, `__fixtures__/${PLUGIN_NAME}`);
-pluginTester({
-  pluginOptions: {
-    '@fluentui/react-button': defaultDependencyReplace,
-    '@fluentui/react-menu': defaultDependencyReplace,
-    '@fluentui/react-link': defaultDependencyReplace,
-    '@fluentui/react-unstable-component': { replace: '@fluentui/react-components/unstable' },
-  },
-  pluginName: PLUGIN_NAME,
-  plugin,
-  fixtures: fixturesDir,
+pluginTester(plugin, PLUGIN_NAME, {
+  '@fluentui/react-unstable-component': { replace: '@fluentui/react-components/unstable' },
 });

--- a/storybook-addon-export-to-codesandbox/src/plugins/pluginTester.ts
+++ b/storybook-addon-export-to-codesandbox/src/plugins/pluginTester.ts
@@ -1,0 +1,20 @@
+import { PluginOptions } from '@babel/core';
+import pluginTester from 'babel-plugin-tester';
+import * as path from 'path';
+
+export default function (plugin: any, pluginName: string, pluginOptions: PluginOptions = {}) {
+  const fixturesDir = path.join(__dirname, `__fixtures__/${pluginName}`);
+  const defaultDependencyReplace = { replace: '@fluentui/react-components' };
+
+  pluginTester({
+    fixtures: fixturesDir,
+    pluginOptions: {
+      '@fluentui/react-button': defaultDependencyReplace,
+      '@fluentui/react-menu': defaultDependencyReplace,
+      '@fluentui/react-link': defaultDependencyReplace,
+      ...pluginOptions,
+    },
+    pluginName,
+    plugin,
+  });
+}

--- a/storybook-addon-export-to-codesandbox/src/plugins/removeStorybookParameters.test.ts
+++ b/storybook-addon-export-to-codesandbox/src/plugins/removeStorybookParameters.test.ts
@@ -1,18 +1,4 @@
-import pluginTester from 'babel-plugin-tester';
-import * as path from 'path';
 import plugin, { PLUGIN_NAME } from './removeStorybookParameters';
+import pluginTester from './pluginTester';
 
-const fixturesDir = path.join(__dirname, `__fixtures__/${PLUGIN_NAME}`);
-
-const defaultDependencyReplace = { replace: '@fluentui/react-components' };
-
-pluginTester({
-  pluginOptions: {
-    '@fluentui/react-button': defaultDependencyReplace,
-    '@fluentui/react-menu': defaultDependencyReplace,
-    '@fluentui/react-link': defaultDependencyReplace,
-  },
-  pluginName: PLUGIN_NAME,
-  plugin,
-  fixtures: fixturesDir,
-});
+pluginTester(plugin, PLUGIN_NAME);

--- a/storybook-addon-export-to-codesandbox/src/plugins/removeStorybookParameters.test.ts
+++ b/storybook-addon-export-to-codesandbox/src/plugins/removeStorybookParameters.test.ts
@@ -1,0 +1,18 @@
+import pluginTester from 'babel-plugin-tester';
+import * as path from 'path';
+import plugin, { PLUGIN_NAME } from './removeStorybookParameters';
+
+const fixturesDir = path.join(__dirname, `__fixtures__/${PLUGIN_NAME}`);
+
+const defaultDependencyReplace = { replace: '@fluentui/react-components' };
+
+pluginTester({
+  pluginOptions: {
+    '@fluentui/react-button': defaultDependencyReplace,
+    '@fluentui/react-menu': defaultDependencyReplace,
+    '@fluentui/react-link': defaultDependencyReplace,
+  },
+  pluginName: PLUGIN_NAME,
+  plugin,
+  fixtures: fixturesDir,
+});

--- a/storybook-addon-export-to-codesandbox/src/plugins/removeStorybookParameters.ts
+++ b/storybook-addon-export-to-codesandbox/src/plugins/removeStorybookParameters.ts
@@ -11,54 +11,21 @@ export const PLUGIN_NAME = 'babel-plugin-remove-storybook-parameters';
  *
  * Another benefit of removing the Storybook specific assignments is that the
  * resulting example is free of unnecessary clutter.
- *
- * The code:
- *  - traverses the program and finds any named exports
- *    - `export` in `export const ButtonAppearance = () => (...`
- *  - finds the first identifier in those exports and saves the name
- *    of those exports to a variable (scoped to the file)
- *    - `ButtonApperance` in `export const ButtonAppearance`
- *  - traverses the program and finds any MemberExpressions
- *  - if the expression's `object` part is an identifier and its name
- *    was saved in the step no. 2, then:
- *    - we try to find the parent AssignmentExpression and if we do,
- *      we remove it.
- *
  */
 export default function removeStorybookParameters(babel: typeof Babel): Babel.PluginObj {
-  const { types: t } = babel;
-
   return {
     name: PLUGIN_NAME,
     visitor: {
-      // It's important to visit Program first and traverse manually, because we need the
-      // exportNodes to be scoped to the file (program)
-      Program(program) {
-        let exportNodes: string[] = [];
-
-        program.traverse({
-          ExportNamedDeclaration(path) {
-            let foundIdForThisExport = false;
-
-            path.traverse({
-              Identifier(idPath) {
-                // Only do this once, we don't want to save any identifiers deeper in the tree
-                if (!foundIdForThisExport) {
-                  exportNodes.push(idPath.node.name);
-                  foundIdForThisExport = true;
-                }
-              },
+      ExportNamedDeclaration(path) {
+        path.traverse({
+          Identifier(idPath) {
+            const binding = idPath.scope.getBinding(idPath.node.name);
+            binding?.referencePaths?.forEach(path => {
+              if (path.parentPath?.isMemberExpression()) {
+                path.parentPath.parentPath?.remove();
+              }
             });
-          },
-
-          MemberExpression(path) {
-            // check if the name of the object in the memberExpression was exported in this file
-            if (t.isIdentifier(path.node.object) && exportNodes.includes(path.node.object.name)) {
-              // we actually have to find the parent, because otherwise we'd just be removing
-              // a left side of an assignment, which breaks things.
-              const parentPath = path.findParent(path => path.isAssignmentExpression());
-              parentPath?.remove();
-            }
+            idPath.stop();
           },
         });
       },

--- a/storybook-addon-export-to-codesandbox/src/plugins/removeStorybookParameters.ts
+++ b/storybook-addon-export-to-codesandbox/src/plugins/removeStorybookParameters.ts
@@ -1,0 +1,33 @@
+import * as Babel from '@babel/core';
+
+export const PLUGIN_NAME = 'babel-plugin-remove-storybook-parameters';
+
+/**
+ * This plugin finds Storybook "parameters" assignment and removes it, if it contains "story" key.
+ * The reason for this is that sometimes "story" is not a hardcoded string, but it is imported from
+ * a markdown file, which results in story being undefined and CodeSandbox example not working.
+ *
+ * Since we dont actually need Storybook parameters in the CodeSandbox anyway,
+ * the easiest thing to do is to remove it altogether.
+ */
+export default function removeStorybookParameters(babel: typeof Babel): Babel.PluginObj {
+  const { types: t } = babel;
+
+  return {
+    name: PLUGIN_NAME,
+    visitor: {
+      Identifier(path) {
+        if (path.node.name === 'story') {
+          const parentPath = path.findParent(
+            path =>
+              path.isAssignmentExpression() &&
+              t.isMemberExpression(path.node.left) &&
+              t.isIdentifier(path.node.left.property) &&
+              path.node.left.property.name === 'parameters',
+          );
+          parentPath?.remove();
+        }
+      },
+    },
+  };
+}

--- a/storybook-addon-export-to-codesandbox/src/plugins/removeStorybookParameters.ts
+++ b/storybook-addon-export-to-codesandbox/src/plugins/removeStorybookParameters.ts
@@ -3,12 +3,27 @@ import * as Babel from '@babel/core';
 export const PLUGIN_NAME = 'babel-plugin-remove-storybook-parameters';
 
 /**
- * This plugin finds Storybook "parameters" assignment and removes it, if it contains "story" key.
- * The reason for this is that sometimes "story" is not a hardcoded string, but it is imported from
- * a markdown file, which results in story being undefined and CodeSandbox example not working.
+ * This plugin finds Storybook specific assignments and removes them.
  *
- * Since we dont actually need Storybook parameters in the CodeSandbox anyway,
- * the easiest thing to do is to remove it altogether.
+ * Main reason for this change is that sometimes "story" is not a hardcoded string
+ * but it is imported from a markdown file, which results in story being undefined
+ * and CodeSandbox example not working.
+ *
+ * Another benefit of removing the Storybook specific assignments is that the
+ * resulting example is free of unnecessary clutter.
+ *
+ * The code:
+ *  - traverses the program and finds any named exports
+ *    - `export` in `export const ButtonAppearance = () => (...`
+ *  - finds the first identifier in those exports and saves the name
+ *    of those exports to a variable (scoped to the file)
+ *    - `ButtonApperance` in `export const ButtonAppearance`
+ *  - traverses the program and finds any MemberExpressions
+ *  - if the expression's `object` part is an identifier and its name
+ *    was saved in the step no. 2, then:
+ *    - we try to find the parent AssignmentExpression and if we do,
+ *      we remove it.
+ *
  */
 export default function removeStorybookParameters(babel: typeof Babel): Babel.PluginObj {
   const { types: t } = babel;
@@ -16,17 +31,36 @@ export default function removeStorybookParameters(babel: typeof Babel): Babel.Pl
   return {
     name: PLUGIN_NAME,
     visitor: {
-      Identifier(path) {
-        if (path.node.name === 'story') {
-          const parentPath = path.findParent(
-            path =>
-              path.isAssignmentExpression() &&
-              t.isMemberExpression(path.node.left) &&
-              t.isIdentifier(path.node.left.property) &&
-              path.node.left.property.name === 'parameters',
-          );
-          parentPath?.remove();
-        }
+      // It's important to visit Program first and traverse manually, because we need the
+      // exportNodes to be scoped to the file (program)
+      Program(program) {
+        let exportNodes: string[] = [];
+
+        program.traverse({
+          ExportNamedDeclaration(path) {
+            let foundIdForThisExport = false;
+
+            path.traverse({
+              Identifier(idPath) {
+                // Only do this once, we don't want to save any identifiers deeper in the tree
+                if (!foundIdForThisExport) {
+                  exportNodes.push(idPath.node.name);
+                  foundIdForThisExport = true;
+                }
+              },
+            });
+          },
+
+          MemberExpression(path) {
+            // check if the name of the object in the memberExpression was exported in this file
+            if (t.isIdentifier(path.node.object) && exportNodes.includes(path.node.object.name)) {
+              // we actually have to find the parent, because otherwise we'd just be removing
+              // a left side of an assignment, which breaks things.
+              const parentPath = path.findParent(path => path.isAssignmentExpression());
+              parentPath?.remove();
+            }
+          },
+        });
       },
     },
   };


### PR DESCRIPTION
Fix for https://github.com/microsoft/fluentui/issues/26181

Currently if the storybook story is imported from a markdown file, the import is removed and the story is undefined in the CodeSandbox example. This breaks the example completely.

Since we don't need the Storybook parameters in the CodeSandbox for anything, the easiest way how to fix this behavior (and improve the example by removing unrelated code), is to remove the Storybook parameters altogether.


Alert Dialog example before the fix:
<img width="1398" alt="Screenshot 2023-01-06 at 15 21 08" src="https://user-images.githubusercontent.com/2070479/211030856-071c4ba1-feb3-4a32-8d6d-1c7857e107c7.png">

Alert Dialog example after the fix:
<img width="1397" alt="Screenshot 2023-01-06 at 15 21 50" src="https://user-images.githubusercontent.com/2070479/211030900-1e128b73-3518-4e90-bf5e-aebdc4a84adc.png">



