### PR TITLE
Added build steps to the README.md

### DIFF
--- a/storybook-addon-export-to-codesandbox/README.md
+++ b/storybook-addon-export-to-codesandbox/README.md
@@ -121,3 +121,9 @@ import { Button } from '../index';
 // After
 import { Button } from '@fluentui/react-button';
 ```
+
+## Build the project
+
+1. Run `yarn` in storybook-addon-export-to-codesandbox folder.
+2. Run `yarn buildBabel:cjs`.
+3. Run `yarn build`.


### PR DESCRIPTION
If project is linked to fluentui repo it won't work without `yarn buildBabel:cjs` step.
I added it to the README.md as it's not obvoius step.