### PR TITLE
fix: keep break lines intact after babel transform

### DIFF
--- a/storybook-addon-export-to-codesandbox/.storybook/preview.js
+++ b/storybook-addon-export-to-codesandbox/.storybook/preview.js
@@ -1,6 +1,11 @@
 import dedent from 'dedent';
 
+/** @type {import('@storybook/addons').Parameters} */
 export const parameters = {
+  docs: {
+    transformSource: (_, story) => story.parameters.fullSource,
+  },
+
   exportToCodeSandbox: {
     requiredDependencies: {
       'react-dom': 'latest', // for React

--- a/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/storybook-stories-fullsource/keep-sourcecode-spacing/code.js
+++ b/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/storybook-stories-fullsource/keep-sourcecode-spacing/code.js
@@ -1,0 +1,3 @@
+var __STORY__ =
+  'import * as React from "react";\nimport { Button } from "@fluentui/react-components";\n\nexport const ButtonAppearance = () => (\n  <>\n    <Button>Default button</Button>\n    <Button appearance="primary">Primary button</Button>\n    <Button appearance="outline">Outline button</Button>\n    <Button appearance="subtle">Subtle button</Button>\n    <Button appearance="transparent">Transparent button</Button>\n  </>\n);\n';
+storyName.parameters = {};

--- a/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/storybook-stories-fullsource/keep-sourcecode-spacing/output.js
+++ b/storybook-addon-export-to-codesandbox/src/plugins/__fixtures__/storybook-stories-fullsource/keep-sourcecode-spacing/output.js
@@ -1,0 +1,4 @@
+var __STORY__ =
+  'import * as React from "react";\nimport { Button } from "@fluentui/react-components";\n\nexport const ButtonAppearance = () => (\n  <>\n    <Button>Default button</Button>\n    <Button appearance="primary">Primary button</Button>\n    <Button appearance="outline">Outline button</Button>\n    <Button appearance="subtle">Subtle button</Button>\n    <Button appearance="transparent">Transparent button</Button>\n  </>\n);\n';
+storyName.parameters = {};
+storyName.parameters.fullSource = __STORY__;

--- a/storybook-addon-export-to-codesandbox/src/plugins/fullsource.ts
+++ b/storybook-addon-export-to-codesandbox/src/plugins/fullsource.ts
@@ -47,6 +47,8 @@ export default function (babel: typeof Babel, options: BabelPluginOptions): Babe
         ) {
           const transformedCode = babel.transformSync(path.node.init.value, {
             ...state.file.opts,
+            compact: false,
+            retainLines: true,
             comments: false,
             plugins: [[modifyImportsPlugin, options], removeStorybookParameters],
           }).code;

--- a/storybook-addon-export-to-codesandbox/stories/ButtonAppearance.stories.tsx
+++ b/storybook-addon-export-to-codesandbox/stories/ButtonAppearance.stories.tsx
@@ -1,15 +1,27 @@
 import * as React from 'react';
-import { Button } from '@fluentui/react-components';
+import { Button, makeStyles } from '@fluentui/react-components';
 
-export const ButtonAppearance = () => (
-  <>
-    <Button>Default button</Button>
-    <Button appearance="primary">Primary button</Button>
-    <Button appearance="outline">Outline button</Button>
-    <Button appearance="subtle">Subtle button</Button>
-    <Button appearance="transparent">Transparent button</Button>
-  </>
-);
+const useStyles = makeStyles({
+  greenButton: {
+    color: 'green',
+  },
+});
+
+export const ButtonAppearance = () => {
+  const styles = useStyles();
+
+  return (
+    <>
+      <Button>Default button</Button>
+      <Button appearance="primary">Primary button</Button>
+      <Button appearance="outline">Outline button</Button>
+      <Button appearance="subtle">Subtle button</Button>
+      <Button appearance="transparent">Transparent button</Button>
+      <Button className={styles.greenButton}>Custom green button</Button>
+    </>
+  );
+};
+
 ButtonAppearance.parameters = {
   docs: {
     description: {


### PR DESCRIPTION
Before:
The babel transform removed all intentional break lines on source code, making the Code Sandbox code harder to read.

![SCR-20230201-rmr](https://user-images.githubusercontent.com/1357885/216136853-7209391a-fb1a-4b39-ac01-893f501a9059.png)

After:
Keep break lines intact with transform. This affects both Code Sandbox export and the "Show Code" button.
![SCR-20230201-rm7](https://user-images.githubusercontent.com/1357885/216136912-34b015aa-13a3-43bc-b0e0-3c86aaee726e.png)
