### PR TITLE
fix: dependency matching for multi-line imports

### DIFF
--- a/storybook-addon-export-to-codesandbox/src/getDepdencies.ts
+++ b/storybook-addon-export-to-codesandbox/src/getDepdencies.ts
@@ -12,7 +12,7 @@ export const getDependencies = (
   requiredDependencies: PackageDependencies,
   optionalDependencies: PackageDependencies,
 ) => {
-  const matches = fileContent.matchAll(/import .* from ['"](.*?)['"];/g);
+  const matches = fileContent.matchAll(/from ['"](.*?)['"];/g);
 
   const dependenciesInCode = Array.from(matches).reduce((dependencies, match) => {
     if (!match[1].startsWith('react/')) {

--- a/storybook-addon-export-to-codesandbox/src/getDependencies.test.ts
+++ b/storybook-addon-export-to-codesandbox/src/getDependencies.test.ts
@@ -6,11 +6,19 @@ describe('getDependencies', () => {
       import { stuff } from 'dependency';
       import * as allStuff from 'dependency1';
       import { moreStuff } from '@dependency/dependency';
+      import {
+        someOtherStuff,
+      } from "@multiline/importDouble";
+      import {
+        someOtherStuff,
+      } from '@multiline/import';
     `;
     const deps = getDependencies(code, {}, {});
 
     expect(deps).toEqual({
       '@dependency/dependency': 'latest',
+      '@multiline/importDouble': 'latest',
+      '@multiline/import': 'latest',
       dependency: 'latest',
       dependency1: 'latest',
     });


### PR DESCRIPTION
This fixes a bug where `@fluentui/react-components` was not always added to the dependencies list.

The issue was that the regex wouldn't match imports like this:

```ts
import {
  FirstImport,
  SecondImport,
} from "@fluentui/react-components";
```

I've updated the regex to always match one and multi-line imports.